### PR TITLE
[BUG-Fix]: Fixed update create-items command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ test:
 	poetry run pytest
 
 create-items:
-	curl -X POST localhost:8000/foo/item/   --data '{"description":"some item description", "public":false}' && echo
-	curl -X POST localhost:8000/foo/item/   --data '{"description":"some item description", "public":true}'
+	curl -X POST localhost:8000/foo/item/ -H 'Content-Type: application/json' --data '{"description":"some item description", "public":false}' && echo
+	curl -X POST localhost:8000/foo/item/ -H 'Content-Type: application/json' --data '{"description":"some item description", "public":true}'
 
 get-items:
 	curl -X GET localhost:8000/foo/item/1 && echo


### PR DESCRIPTION
Hello there!
I'm using MacBook M1 with cURL: 7.77.0, and without explicitly adding the json header,  the server rejects the request with the following error message:

`{"detail":[{"loc":["body"],"msg":"value is not a valid dict","type":"type_error.dict"}]}`

Problem solved by adding: `Content-Type: application/json`